### PR TITLE
Add Sticky HAL Eye That Follows Scroll and Adapts to Mobile

### DIFF
--- a/js/hal-eye-sticky.js
+++ b/js/hal-eye-sticky.js
@@ -4,22 +4,38 @@
 document.addEventListener('DOMContentLoaded', function() {
   var halEye = document.getElementById('hal-eye');
   var stickyEye = document.getElementById('hal-eye-sticky');
-  // Clone the HAL eye's styles and structure
   stickyEye.className = 'hal-eye';
   stickyEye.style.position = 'fixed';
-  stickyEye.style.top = '20px';
-  stickyEye.style.right = '20px';
+  stickyEye.style.top = '10px';
+  stickyEye.style.right = '10px';
+  stickyEye.style.left = '';
   stickyEye.style.zIndex = '9999';
   stickyEye.style.margin = '0';
   stickyEye.style.display = 'none';
+
+  // Responsive adjustment for mobile
+  function adjustStickyPosition() {
+    if (window.innerWidth <= 600) {
+      stickyEye.style.left = '50%';
+      stickyEye.style.right = '';
+      stickyEye.style.transform = 'translateX(-50%)';
+    } else {
+      stickyEye.style.left = '';
+      stickyEye.style.right = '10px';
+      stickyEye.style.transform = '';
+    }
+  }
+
   function checkSticky() {
     var rect = halEye.getBoundingClientRect();
     if (rect.bottom < 0) {
       stickyEye.style.display = 'block';
+      adjustStickyPosition();
     } else {
       stickyEye.style.display = 'none';
     }
   }
   window.addEventListener('scroll', checkSticky);
+  window.addEventListener('resize', adjustStickyPosition);
   checkSticky();
 });


### PR DESCRIPTION
- Implements a sticky version of the HAL eye that appears at the top right of the viewport when the user scrolls past the original eye.
- On mobile devices, the sticky eye shifts to the top center for better visibility.
- Moves sticky eye logic to a dedicated JavaScript file ([hal-eye-sticky.js](vscode-file://vscode-app/c:/Users/m2web/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) for maintainability.
- Ensures the sticky eye remains visible and anchored regardless of device or scroll position.
- Cleans up inline scripts from [index.html](vscode-file://vscode-app/c:/Users/m2web/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and references the new JS resource.